### PR TITLE
Feature/logging levels

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"log"
+	"os"
+)
+
+// ServiceLogger represents a logger with logging level prefixes for a specific service.
+type ServiceLogger struct {
+	ServiceName string
+	Debug       *log.Logger
+	Info        *log.Logger
+	Fatal       *log.Logger
+	Error       *log.Logger
+}
+
+// NewServiceLogger returns a logger with designated logging levels for a particular service.
+func NewServiceLogger(serviceName string) ServiceLogger {
+	logger := ServiceLogger{
+		ServiceName: serviceName,
+		Debug:       log.New(os.Stdout, "DEBUG: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		Info:        log.New(os.Stdout, "INFO: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		Fatal:       log.New(os.Stdout, "FATAL: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		Error:       log.New(os.Stdout, "ERROR: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+	}
+	return logger
+}

--- a/logger.go
+++ b/logger.go
@@ -12,16 +12,18 @@ type ServiceLogger struct {
 	Info        *log.Logger
 	Fatal       *log.Logger
 	Error       *log.Logger
+	*log.Logger
 }
 
 // NewServiceLogger returns a logger with designated logging levels for a particular service.
 func NewServiceLogger(serviceName string) ServiceLogger {
 	logger := ServiceLogger{
-		ServiceName: serviceName,
-		Debug:       log.New(os.Stdout, "DEBUG: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		Info:        log.New(os.Stdout, "INFO: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		Fatal:       log.New(os.Stdout, "FATAL: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		Error:       log.New(os.Stdout, "ERROR: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		serviceName,
+		log.New(os.Stdout, "DEBUG: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "INFO: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "FATAL: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "ERROR: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
 	}
 	return logger
 }

--- a/logger.go
+++ b/logger.go
@@ -20,11 +20,11 @@ type ServiceLogger struct {
 func NewServiceLogger(serviceName string, debug bool) ServiceLogger {
 	logger := ServiceLogger{
 		serviceName,
-		log.New(os.Stdout, "DEBUG: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, "INFO: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, "FATAL: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, "ERROR: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "DEBUG: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "INFO: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "FATAL: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "ERROR: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
 	}
 	if debug == false {
 		logger.Debug.SetOutput(ioutil.Discard)

--- a/logger.go
+++ b/logger.go
@@ -25,6 +25,26 @@ type ServiceLogger struct {
 	Debug    *log.Logger
 }
 
+// Debugf is equivalent to Printf with "DEBUG: SERVICENAME: " prepended.
+func (sl *ServiceLogger) Debugf(format string, v ...interface{}) {
+	sl.Debug.Printf(format, v...)
+}
+
+// Infof is equivalent to Printf with "INFO: SERVICENAME: " prepended.
+func (sl *ServiceLogger) Infof(format string, v ...interface{}) {
+	sl.Info.Printf(format, v...)
+}
+
+// Errorf is equivalent to Printf with "ERROR: SERVICENAME: " prepended.
+func (sl *ServiceLogger) Errorf(format string, v ...interface{}) {
+	sl.Error.Printf(format, v...)
+}
+
+// Criticalf is equivalent to Printf with "CRITICAL: SERVICENAME: " prepended.
+func (sl *ServiceLogger) Criticalf(format string, v ...interface{}) {
+	sl.Critical.Printf(format, v...)
+}
+
 // NewServiceLogger returns a logger with designated logging levels for a particular service.
 func NewServiceLogger(serviceName string, level int) ServiceLogger {
 	logger := ServiceLogger{

--- a/logger.go
+++ b/logger.go
@@ -6,28 +6,49 @@ import (
 	"os"
 )
 
+const (
+	OFF      = iota // 0
+	SERVICE  = iota
+	CRITICAL = iota
+	ERROR    = iota
+	INFO     = iota
+	DEBUG    = iota // 5
+)
+
 // ServiceLogger represents a logger with logging level prefixes for a specific service.
 type ServiceLogger struct {
 	ServiceName string
-	Debug       *log.Logger
-	Info        *log.Logger
-	Fatal       *log.Logger
-	Error       *log.Logger
 	*log.Logger
+	Critical *log.Logger
+	Error    *log.Logger
+	Info     *log.Logger
+	Debug    *log.Logger
 }
 
 // NewServiceLogger returns a logger with designated logging levels for a particular service.
-func NewServiceLogger(serviceName string, debug bool) ServiceLogger {
+func NewServiceLogger(serviceName string, level int) ServiceLogger {
 	logger := ServiceLogger{
 		serviceName,
-		log.New(os.Stdout, "DEBUG: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, "INFO: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, "FATAL: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
-		log.New(os.Stdout, "ERROR: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
 		log.New(os.Stdout, serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "CRITICAL: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "ERROR: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "INFO: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+		log.New(os.Stdout, "DEBUG: "+serviceName+": ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
 	}
-	if debug == false {
+	if level < DEBUG {
 		logger.Debug.SetOutput(ioutil.Discard)
+	}
+	if level < INFO {
+		logger.Info.SetOutput(ioutil.Discard)
+	}
+	if level < ERROR {
+		logger.Error.SetOutput(ioutil.Discard)
+	}
+	if level < CRITICAL {
+		logger.Critical.SetOutput(ioutil.Discard)
+	}
+	if level < SERVICE {
+		logger.SetOutput(ioutil.Discard)
 	}
 	return logger
 }

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 )
@@ -16,7 +17,7 @@ type ServiceLogger struct {
 }
 
 // NewServiceLogger returns a logger with designated logging levels for a particular service.
-func NewServiceLogger(serviceName string) ServiceLogger {
+func NewServiceLogger(serviceName string, debug bool) ServiceLogger {
 	logger := ServiceLogger{
 		serviceName,
 		log.New(os.Stdout, "DEBUG: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
@@ -24,6 +25,9 @@ func NewServiceLogger(serviceName string) ServiceLogger {
 		log.New(os.Stdout, "FATAL: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
 		log.New(os.Stdout, "ERROR: "+serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
 		log.New(os.Stdout, serviceName+":", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),
+	}
+	if debug == false {
+		logger.Debug.SetOutput(ioutil.Discard)
 	}
 	return logger
 }


### PR DESCRIPTION
Since our go services are taking off logging levels might be a nice feature. 

I've taken some influence from https://dave.cheney.net/2015/11/05/lets-talk-about-logging, in case you're wondering why I didn't include warning. Suggestions on logging standards are appreciated!

The random `*log.Logger` below all of the levels means that we won't break previous logging such as `logger.Printf("x")`, and will just have the service name prepended.