### PR TITLE
Feature/logging interface

### DIFF
--- a/lifecycle/manager.go
+++ b/lifecycle/manager.go
@@ -49,9 +49,9 @@ type Manager struct {
 	WG         sync.WaitGroup
 }
 
-// New initializes a new lifecycle.Manager object that can be used
+// NewManager initializes a new lifecycle.Manager object that can be used
 // to manage the lifecycle of items such as connections to a database.
-func New(logger logging.Logger) Manager {
+func NewManager(logger logging.Logger) Manager {
 	closerChan := make(chan CloseFunc)
 	shutdown := make(chan struct{})
 	var stopwg sync.WaitGroup

--- a/lifecycle/manager.go
+++ b/lifecycle/manager.go
@@ -1,4 +1,4 @@
-package connectionmanager
+package lifecycle
 
 import (
 	"sync"

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 )
 
@@ -10,6 +11,7 @@ import (
 // log level aware. This is especially useful when another interface supports
 // logging with logging levels. This interface can be embedded.
 type Logger interface {
+	Raw() *log.Logger
 	SetLevel(string)
 	Print(...interface{})
 	Printf(string, ...interface{})

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -6,6 +6,28 @@ import (
 	"os"
 )
 
+// Logger is an interface defining object that providers logging methods that are
+// log level aware. This is especially useful when another interface supports
+// logging with logging levels. This interface can be embedded.
+type Logger interface {
+	SetLevel(string)
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+	Debug(...interface{})
+	Debugf(string, ...interface{})
+	Debugln(...interface{})
+	Info(...interface{})
+	Infof(string, ...interface{})
+	Infoln(...interface{})
+	Error(...interface{})
+	Errorf(string, ...interface{})
+	Errorln(...interface{})
+	Critical(...interface{})
+	Criticalf(string, ...interface{})
+	Criticalln(...interface{})
+}
+
 // LogWriter maps string values to io.Writer interfaces intended for logging output.
 //
 // This function is intended to provide a standard way of mapping environment-based

--- a/logging/servicelogger.go
+++ b/logging/servicelogger.go
@@ -32,6 +32,12 @@ func NewServiceLogger(out io.Writer, serviceName string, level string) ServiceLo
 	return logger
 }
 
+// Raw returns the underlying log.Logger for use in methods that do not support a full
+// logging.Logger with log levels.
+func (sl *ServiceLogger) Raw() *log.Logger {
+	return sl.Logger
+}
+
 // SetLevel allows the log level of the ServiceLogger to be updated based on
 // supported log level strings. These include in order:
 // 	- "OFF"


### PR DESCRIPTION
Adds an interface for the ServiceLogger allowing more flexible logging usages in serves.

Also changes the name of the ConnectionManager to `lifecycle.Manager` helping indicate it really does generally manage the life cycle of items, not only things like long-lived connections (though it does that very well).