### PR TITLE
Copy raw bytes instead of re-encoding bytes in the JSONLoggingMiddleware

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -80,8 +80,6 @@ func JSONLoggingMiddleware(logger *logging.ServiceLogger) Middleware {
 		var rawBodyBuffer bytes.Buffer
 		// Copy over raw bytes to the rawBodyBuffer when the body is read.
 		body := io.TeeReader(r.Body, &rawBodyBuffer)
-		// Repopulate the request body for the ultimate consumer of this request
-		r.Body = ioutil.NopCloser(&rawBodyBuffer)
 		var requestBody interface{}
 		json.NewDecoder(body).Decode(&requestBody)
 		logger.Print(map[string]interface{}{

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -76,8 +77,13 @@ func DecorateHandlerFunc(f func(http.ResponseWriter, *http.Request), middleware 
 // the request and de-serialized JSON body.
 func JSONLoggingMiddleware(logger *logging.ServiceLogger) Middleware {
 	return MiddlewareFunc(func(h http.Handler, w http.ResponseWriter, r *http.Request) {
+		var rawBodyBuffer bytes.Buffer
+		// Copy over raw bytes to the rawBodyBuffer when the body is read.
+		body := io.TeeReader(r.Body, &rawBodyBuffer)
+		// Repopulate the request body for the ultimate consumer of this request
+		r.Body = ioutil.NopCloser(&rawBodyBuffer)
 		var requestBody interface{}
-		json.NewDecoder(r.Body).Decode(&requestBody)
+		json.NewDecoder(body).Decode(&requestBody)
 		logger.Print(map[string]interface{}{
 			"request_method":    r.Method,
 			"request_uri":       r.RequestURI,
@@ -86,9 +92,7 @@ func JSONLoggingMiddleware(logger *logging.ServiceLogger) Middleware {
 			"request_body":      requestBody,
 		})
 		// Repopulate body with the data read
-		jsonBytes := new(bytes.Buffer)
-		json.NewEncoder(jsonBytes).Encode(requestBody)
-		r.Body = ioutil.NopCloser(jsonBytes)
+		r.Body = ioutil.NopCloser(&rawBodyBuffer)
 		h.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
When working with Stripe webhook signature validation, we found the JSONLoggingMiddleware was modifying body payloads and stripping white space because it was decoding and re encoding the JSON bytes. This update copies the bytes using a TeeReader rather than doing a re-encode operation to ensure the middleware is a noop on the body bytes.