### PR TITLE
Don't log client secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	mellium.im/sasl v0.2.1 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Update jsonlogging middleware to use level logging functionality of its logger and to accept a blacklist of regexes for routes not to log.