### PR TITLE
Await interval

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -29,3 +29,21 @@ func Await(ready Ready, maxRetries int) bool {
 	}
 	return false
 }
+
+// AwaitInterval waits until the ready function is ready or errors, returning
+// success and error (if any). It checks if the function is ready once, then
+// waits the specified time interval (in seconds) and retries. If the specified
+// timeout is past (taken in seconds) it will return false.
+func AwaitInterval(ready Ready, interval int, timeout int) bool {
+	timeoutTime := time.Now().Add(time.Duration(timeout) * time.Second)
+	intervalTime := time.Duration(interval) * time.Second
+	for timeoutTime.Before(time.Now()) {
+		success := ready()
+		if !success {
+			time.Sleep(intervalTime)
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/retry.go
+++ b/retry.go
@@ -37,7 +37,7 @@ func Await(ready Ready, maxRetries int) bool {
 func AwaitInterval(ready Ready, interval int, timeout int) bool {
 	timeoutTime := time.Now().Add(time.Duration(timeout) * time.Second)
 	intervalTime := time.Duration(interval) * time.Second
-	for timeoutTime.Before(time.Now()) {
+	for timeoutTime.After(time.Now()) {
 		success := ready()
 		if !success {
 			time.Sleep(intervalTime)


### PR DESCRIPTION
Add an await version that does a straight interval with a timeout instead of an exponential backoff. When you get into the longer backoff periods, in particular for the start service, it takes an extra couple minutes to realize all the services are ready because the exponential scale adds up. Health-checks are pretty cheap, so running them every couple of seconds on an interval keeps things feeling a little faster.