### PR TITLE
Logging error

### DIFF
--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -227,7 +227,6 @@ func NewSQSQueue(config SQSQueueConfig) (Queue, error) {
 	if err != nil {
 		return sqsQueue, err
 	}
-	fmt.Printf("THIS IS CREATE QUEUE RESP %+v\n", createQueueResponse)
 	sqsQueue = &SQSQueue{
 		Name:                     config.QueueName,
 		url:                      *createQueueResponse.QueueUrl,

--- a/queue/sqs.go
+++ b/queue/sqs.go
@@ -227,6 +227,7 @@ func NewSQSQueue(config SQSQueueConfig) (Queue, error) {
 	if err != nil {
 		return sqsQueue, err
 	}
+	fmt.Printf("THIS IS CREATE QUEUE RESP %+v\n", createQueueResponse)
 	sqsQueue = &SQSQueue{
 		Name:                     config.QueueName,
 		url:                      *createQueueResponse.QueueUrl,


### PR DESCRIPTION
When the decoder fails (the body is not json), the error is not handled and the body that is repopulated is corrupt - ex: half the body is copied back to the response and then the following handlers have a partial body.

-> json.NewDecoder(body).Decode(&requestBody)
