### PR TITLE
Feature/query time

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -58,6 +58,9 @@ var dlTimingKey struct{} = struct{}{}
 // BeforeQuery is a function that will be invoked
 // before any database query is run with the query to run.
 func (d dbLogger) BeforeQuery(q *pg.QueryEvent) {
+	if q.Ctx == nil {
+		q.Ctx = context.Background()
+	}
 	q.Ctx = context.WithValue(q.Ctx, dlTimingKey, time.Now())
 }
 

--- a/database/db.go
+++ b/database/db.go
@@ -69,12 +69,12 @@ func (d dbLogger) BeforeQuery(q *pg.QueryEvent) {
 func (d dbLogger) AfterQuery(q *pg.QueryEvent) {
 	query, err := q.FormattedQuery()
 	if err != nil {
-		d.logger.Errorf("error %q executing query\n%+v ", err, query)
+		d.logger.Errorf("error %q executing query:\n%+v ", err, query)
 		return
 	}
 	start, ok := q.Ctx.Value(dlTimingKey).(time.Time)
 	if !ok {
-		d.logger.Errorf("Unable find timing context in query: ", query)
+		d.logger.Errorf("Unable find timing context in query:\n%+v ", query)
 		return
 	}
 	d.logger.Infof("executed query in %s:\n%+v", time.Now().Sub(start), query)

--- a/database/db.go
+++ b/database/db.go
@@ -69,7 +69,7 @@ func (d dbLogger) BeforeQuery(q *pg.QueryEvent) {
 func (d dbLogger) AfterQuery(q *pg.QueryEvent) {
 	query, err := q.FormattedQuery()
 	if err != nil {
-		d.logger.Errorf("error %q executing query:\n%+v ", err, query)
+		d.logger.Errorf("error %q formatting query:\n%+v ", err, query)
 		return
 	}
 	start, ok := q.Ctx.Value(dlTimingKey).(time.Time)

--- a/database/db.go
+++ b/database/db.go
@@ -77,7 +77,7 @@ func (d dbLogger) AfterQuery(q *pg.QueryEvent) {
 		d.logger.Errorf("Unable find timing context in query: ", query)
 		return
 	}
-	d.logger.Infof("executed query in %s: %s", time.Now().Sub(start), query)
+	d.logger.Infof("executed query in %s:\n%+v", time.Now().Sub(start), query)
 }
 
 // New returns a new DB object which wraps a connection to the database specified in config


### PR DESCRIPTION
- Updates query logging to display at INFO level
- Adds execution time to query logs

```
2020-12-10T19:04:33.020Z  INFO    identity-service        pg@v8.0.3+incompatible/hook.go:102      executed query in 10.38497ms:
SELECT "realm"."realm_id", "realm"."name", "realm"."domain", "realm"."created_by_client_id", "realm"."created_for_account_id", "realm"."active", "realm"."created_at", "realm"."broker_identity_tozny_id" FROM realms AS "realm" WHERE (domain = 'local')
```