### PR TITLE
Query print fix.

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -71,7 +71,7 @@ func (d dbLogger) AfterQuery(ctx context.Context, q *pg.QueryEvent) error {
 		d.logger.Errorf("Unable find timing context in query:\n%+v ", query)
 		return nil
 	}
-	d.logger.Infof("executed query in %s:\n%+v", time.Now().Sub(start), query)
+	d.logger.Infof("executed query in %s:\n%+v", time.Since(start), string(query))
 	return nil
 }
 


### PR DESCRIPTION
Executed queries are printed as bytes so converting it to string gives us readable format.