### PR TITLE
log level issue

### DIFF
--- a/logging/syslog_format._logging.go
+++ b/logging/syslog_format._logging.go
@@ -36,16 +36,19 @@ const (
 	NonTransparentFraming Framing = iota
 	OctetCountingFraming
 	DefaultFraming = NonTransparentFraming
-
-	LOG_EMERG Priority = iota
-	LOG_ALERT
-	LOG_CRIT
-	LOG_ERR
-	LOG_WARNING
-	LOG_NOTICE
-	LOG_INFO
-	LOG_DEBUG
 )
+
+const (
+	LOG_EMERG   Priority = iota // 0
+	LOG_ALERT                   // 1
+	LOG_CRIT                    // 2
+	LOG_ERR                     // 3
+	LOG_WARNING                 // 4
+	LOG_NOTICE                  // 5
+	LOG_INFO                    // 6
+	LOG_DEBUG                   // 7
+)
+
 const (
 	// Facility.
 


### PR DESCRIPTION
Issue:
Incorrect syslog severity levels.

Fix:
In Go, iota increments for every constant spec within a const block and does not reset until a new const block begins. Because of this, by the time LOG_EMERG Priority = iota was reached, iota had already incremented to 9 instead of starting at 0. so as a fix, moved the LOG_EMERG to another const .